### PR TITLE
Feat/parity v6.0.137

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.0] - 2026-03-29
 
-TS SDK parity — commit range `ed17fe86d..429b88a79` (13 PRDs, 244 tasks).
+TS SDK parity — fully compatible with TS AI SDK v6.0.137.
+Commit range `ed17fe86d..429b88a79` plus v6.0.137 backports (13 PRDs, 244 tasks).
 Full release notes: `release_notes/RELEASE_NOTES_V0.4.0.md`.
 
 ### Breaking Changes
@@ -44,14 +45,16 @@ Full release notes: `release_notes/RELEASE_NOTES_V0.4.0.md`.
 - Beta header `code-execution-web-tools-2026-02-09` auto-injected for 20260209 tools
 
 #### OpenAI Provider
-- **GPT-5.4 model family** — `gpt-5.4`, `gpt-5.4-pro`, dated variants; `gpt-5.3-chat-latest`
+- **GPT-5.4 model family** — `gpt-5.4`, `gpt-5.4-pro`, `gpt-5.4-mini`, `gpt-5.4-nano`, dated variants; `gpt-5.3-chat-latest`
 - **Responses API compaction** — parsed as `CustomContent` with `Kind: "openai-compaction"`
+- **`response.failed` SSE event** — maps `incomplete_details.reason` to finish reason, falls back to `error`
 - **`ToolSearch(args)`** factory — server (default) and client execution modes
 - **`CustomTool.Name` removed** — name supplied via `ToTool(name)` method
 - **store=false** strips unencrypted reasoning from assistant history
 
 #### XAI Provider
 - **Responses API as default** with `ChatCompletionsLanguageModel()` opt-in
+- **Grok 4.20 GA models** — multi-agent, reasoning, non-reasoning variants
 - Multi-image editing, b64_json output, quality/user params
 - `CostInUsdTicks` in image and video metadata
 - `ReasoningSummary` option, `ModerationError` type, `Logprobs`/`TopLogprobs`

--- a/docs/05-providers/10-xai.mdx
+++ b/docs/05-providers/10-xai.mdx
@@ -53,6 +53,9 @@ export XAI_API_KEY=xai-...
 | `grok-3-mini` | Smaller, faster Grok 3 variant |
 | `grok-4` | Latest Grok 4 model |
 | `grok-4-latest` | Alias for latest Grok 4 |
+| `grok-4.20-multi-agent` | Multi-agent orchestration |
+| `grok-4.20-reasoning` | Reasoning-optimized |
+| `grok-4.20-non-reasoning` | Fast non-reasoning |
 
 ### Image models
 

--- a/pkg/providers/openai/model_ids.go
+++ b/pkg/providers/openai/model_ids.go
@@ -84,6 +84,10 @@ const (
 	ModelGPT54Pro           = "gpt-5.4-pro"
 	ModelGPT542026_03_05    = "gpt-5.4-2026-03-05"
 	ModelGPT54Pro2026_03_05 = "gpt-5.4-pro-2026-03-05"
+	ModelGPT54Mini             = "gpt-5.4-mini"
+	ModelGPT54Mini2026_03_17   = "gpt-5.4-mini-2026-03-17"
+	ModelGPT54Nano             = "gpt-5.4-nano"
+	ModelGPT54Nano2026_03_17   = "gpt-5.4-nano-2026-03-17"
 )
 
 // Image model ID constants for OpenAI image generation models.

--- a/pkg/providers/openai/responses/api_types.go
+++ b/pkg/providers/openai/responses/api_types.go
@@ -434,6 +434,21 @@ type ResponseCompletedEvent struct {
 	} `json:"response"`
 }
 
+// ResponseFailedEvent is emitted when the response fails (e.g. max tokens exceeded).
+type ResponseFailedEvent struct {
+	Type     string `json:"type"` // "response.failed"
+	Response struct {
+		ID          string             `json:"id"`
+		ServiceTier string             `json:"service_tier,omitempty"`
+		Usage       ResponsesAPIUsage  `json:"usage"`
+		Error       *struct {
+			Code    string `json:"code,omitempty"`
+			Message string `json:"message,omitempty"`
+		} `json:"error,omitempty"`
+		IncompleteDetails *IncompleteDetails `json:"incomplete_details,omitempty"`
+	} `json:"response"`
+}
+
 // ResponsesStreamErrorEvent carries an API error during streaming.
 type ResponsesStreamErrorEvent struct {
 	Type    string `json:"type"` // "error"

--- a/pkg/providers/openai/responses_language_model.go
+++ b/pkg/providers/openai/responses_language_model.go
@@ -646,6 +646,38 @@ func (s *responsesStream) Next() (*provider.StreamChunk, error) {
 			ProviderMetadata: meta,
 		}, nil
 
+	case "response.failed":
+		var e responses.ResponseFailedEvent
+		if err := json.Unmarshal([]byte(event.Data), &e); err != nil {
+			s.err = io.EOF
+			return nil, io.EOF
+		}
+		usage := convertResponsesUsage(e.Response.Usage)
+		finishReason := types.FinishReason("error")
+		if e.Response.IncompleteDetails != nil && e.Response.IncompleteDetails.Reason != "" {
+			finishReason = mapResponsesFinishReason(e.Response.IncompleteDetails, false)
+		}
+
+		metaMap := map[string]interface{}{}
+		if e.Response.ID != "" {
+			metaMap["responseId"] = e.Response.ID
+		}
+		if e.Response.ServiceTier != "" {
+			metaMap["serviceTier"] = e.Response.ServiceTier
+		}
+		var meta json.RawMessage
+		if len(metaMap) > 0 {
+			meta, _ = json.Marshal(metaMap)
+		}
+
+		s.err = io.EOF
+		return &provider.StreamChunk{
+			Type:             provider.ChunkTypeFinish,
+			FinishReason:     finishReason,
+			Usage:            &usage,
+			ProviderMetadata: meta,
+		}, nil
+
 	case "error":
 		var e responses.ResponsesStreamErrorEvent
 		if err := json.Unmarshal([]byte(event.Data), &e); err != nil {

--- a/pkg/providers/xai/model_ids.go
+++ b/pkg/providers/xai/model_ids.go
@@ -46,6 +46,24 @@ const (
 
 	// ModelGrokCodeFast1 — Grok Code fast model
 	ModelGrokCodeFast1 = "grok-code-fast-1"
+
+	// ModelGrok420MultiAgent — Grok 4.20 multi-agent model (GA)
+	ModelGrok420MultiAgent = "grok-4.20-multi-agent"
+
+	// ModelGrok420MultiAgent0309 — Grok 4.20 multi-agent dated release (2025-03-09)
+	ModelGrok420MultiAgent0309 = "grok-4.20-multi-agent-0309"
+
+	// ModelGrok420NonReasoning — Grok 4.20 non-reasoning model (GA)
+	ModelGrok420NonReasoning = "grok-4.20-non-reasoning"
+
+	// ModelGrok4200309NonReasoning — Grok 4.20 non-reasoning dated release (2025-03-09)
+	ModelGrok4200309NonReasoning = "grok-4.20-0309-non-reasoning"
+
+	// ModelGrok420Reasoning — Grok 4.20 reasoning model (GA)
+	ModelGrok420Reasoning = "grok-4.20-reasoning"
+
+	// ModelGrok4200309Reasoning — Grok 4.20 reasoning dated release (2025-03-09)
+	ModelGrok4200309Reasoning = "grok-4.20-0309-reasoning"
 )
 
 // Image model ID constants for xAI Grok image generation models.

--- a/release_notes/RELEASE_NOTES_V0.4.0.md
+++ b/release_notes/RELEASE_NOTES_V0.4.0.md
@@ -2,11 +2,12 @@
 
 ## Overview
 
-Version 0.4.0 closes the gap to TS AI SDK commit range `ed17fe86d..429b88a79`
-with 13 PRDs and 244 tasks across 3 priority waves. Highlights: top-level
-reasoning parameter, SSRF protection, streaming architecture refactor, deferred
-provider tool results, new Anthropic tools, OpenAI Responses API features, XAI
-Responses API migration, and a new Prodia provider.
+Version 0.4.0 achieves full parity with TS AI SDK v6.0.137 (commit range
+`ed17fe86d..429b88a79` plus v6.0.137 backports). 13 PRDs and 244 tasks across
+3 priority waves. Highlights: top-level reasoning parameter, SSRF protection,
+streaming architecture refactor, deferred provider tool results, new Anthropic
+tools, OpenAI Responses API features, XAI Responses API migration, and a new
+Prodia provider.
 
 ## Installation
 
@@ -312,7 +313,8 @@ provider-specific functionality.
 
 ---
 
-**TS SDK Commit Range:** `ed17fe86d..429b88a79`
+**TS SDK Parity:** v6.0.137 (fully compatible)
+**TS SDK Commit Range:** `ed17fe86d..429b88a79` plus v6.0.137 backports
 **Total PRDs:** 13
 **Total Tasks:** 244
 **Branch:** `release/0.4.0`


### PR DESCRIPTION
Add grok-4.20 GA models to xAI provider docs. Add gpt-5.4-mini/nano
  and response.failed event to changelog. Update release notes and
  changelog to reference full v6.0.137 parity.