### PR TITLE
feat(openai): expose Headers and HTTPClient on Config

### DIFF
--- a/pkg/providers/openai/provider.go
+++ b/pkg/providers/openai/provider.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"fmt"
+	netHTTP "net/http"
 
 	"github.com/digitallysavvy/go-ai/pkg/internal/http"
 	"github.com/digitallysavvy/go-ai/pkg/provider"
@@ -31,6 +32,17 @@ type Config struct {
 
 	// Project is the optional project ID
 	Project string
+
+	// Headers are additional HTTP headers sent with every request. They are
+	// merged on top of the default Authorization / OpenAI-* headers, so callers
+	// can override them when targeting OpenAI-compatible endpoints that require
+	// custom headers (e.g. GitHub Copilot's Editor-Version, Copilot-Integration-Id).
+	Headers map[string]string
+
+	// HTTPClient overrides the underlying *net/http.Client. Useful for plugging
+	// in custom transports (proxy, tracing, retry middleware) or for tests.
+	// If nil, the default shared client is used.
+	HTTPClient *netHTTP.Client
 }
 
 // New creates a new OpenAI provider with the given configuration
@@ -40,7 +52,7 @@ func New(cfg Config) *Provider {
 		baseURL = DefaultBaseURL
 	}
 
-	// Create HTTP client with default headers
+	// Build default headers; user-supplied Headers override these.
 	headers := map[string]string{
 		"Authorization": fmt.Sprintf("Bearer %s", cfg.APIKey),
 	}
@@ -53,9 +65,14 @@ func New(cfg Config) *Provider {
 		headers["OpenAI-Project"] = cfg.Project
 	}
 
+	for k, v := range cfg.Headers {
+		headers[k] = v
+	}
+
 	client := http.NewClient(http.Config{
-		BaseURL: baseURL,
-		Headers: headers,
+		BaseURL:    baseURL,
+		Headers:    headers,
+		HTTPClient: cfg.HTTPClient,
 	})
 
 	return &Provider{

--- a/pkg/providers/openai/provider_test.go
+++ b/pkg/providers/openai/provider_test.go
@@ -1,0 +1,88 @@
+package openai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestNew_CustomHeaders_Override verifies that user-supplied Headers are sent
+// on outgoing requests in addition to (and overriding) the default Authorization
+// / OpenAI-* headers. This enables targeting OpenAI-compatible endpoints that
+// require custom headers (e.g. GitHub Copilot, internal proxies).
+func TestNew_CustomHeaders_Override(t *testing.T) {
+	type captured struct {
+		auth        string
+		editor      string
+		integration string
+	}
+	var got captured
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got.auth = r.Header.Get("Authorization")
+		got.editor = r.Header.Get("Editor-Version")
+		got.integration = r.Header.Get("Copilot-Integration-Id")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	p := New(Config{
+		APIKey:  "key-default",
+		BaseURL: srv.URL,
+		Headers: map[string]string{
+			"Authorization":          "Bearer copilot-token",
+			"Editor-Version":         "vscode/1.99.0",
+			"Copilot-Integration-Id": "vscode-chat",
+		},
+	})
+
+	// Trigger a request so the headers are emitted.
+	_, err := p.client.Get(context.Background(), "/")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.auth != "Bearer copilot-token" {
+		t.Errorf("Authorization = %q, want override %q", got.auth, "Bearer copilot-token")
+	}
+	if got.editor != "vscode/1.99.0" {
+		t.Errorf("Editor-Version = %q, want %q", got.editor, "vscode/1.99.0")
+	}
+	if got.integration != "vscode-chat" {
+		t.Errorf("Copilot-Integration-Id = %q, want %q", got.integration, "vscode-chat")
+	}
+}
+
+// TestNew_HTTPClient_Override verifies that a caller-supplied *http.Client is
+// used by the provider. We detect this by routing through a custom transport.
+func TestNew_HTTPClient_Override(t *testing.T) {
+	called := false
+	custom := &http.Client{
+		Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			called = true
+			return &http.Response{
+				StatusCode: 200,
+				Body:       http.NoBody,
+				Header:     http.Header{},
+				Request:    r,
+			}, nil
+		}),
+	}
+
+	p := New(Config{
+		APIKey:     "k",
+		BaseURL:    "http://example.invalid",
+		HTTPClient: custom,
+	})
+	_, _ = p.client.Get(context.Background(), "/")
+
+	if !called {
+		t.Fatal("custom HTTPClient transport was not invoked")
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }


### PR DESCRIPTION
Allow callers to inject custom HTTP headers and a custom *http.Client when constructing the OpenAI provider. This is required to target OpenAI-compatible endpoints that need extra headers (e.g. GitHub Copilot needs Editor-Version + Copilot-Integration-Id) or to plug in custom transports for tracing, retry middleware, and tests.

User-supplied Headers are merged on top of the default Authorization / OpenAI-Organization / OpenAI-Project headers, so callers can override the defaults entirely (e.g. swap in a Copilot bearer token).

Tests cover both code paths.

<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

## Summary

<!-- What did you change? -->

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
